### PR TITLE
tool validator

### DIFF
--- a/act/types/etc/object-types.json
+++ b/act/types/etc/object-types.json
@@ -106,7 +106,7 @@
   },
   {
     "name": "tool",
-    "validator": "^([\\. /a-z0-9_-]+)|(\\[placeholder\\[[a-f0-9]{64}\\]\\])$"
+    "validator": "(^[^A-Z]+$)|(\\[placeholder\\[[a-f0-9]{64}\\]\\])"
   },
   {
     "name": "toolType"


### PR DESCRIPTION
Use same validator on `tool` as we have impelemtented on `threatActor`.

Allow everything, except uppercase.