### PR TITLE
Update tests and raise error on type error on object_value

### DIFF
--- a/act/types/types.py
+++ b/act/types/types.py
@@ -55,6 +55,11 @@ def get_object_validator(object_type: Text) -> Text:
 def object_validates(object_type: Text, object_value: Text) -> bool:
     """Validate object using current valdiator"""
 
+    if not isinstance(object_value, Text):
+        raise TypeError(
+            f"Illegal type for argument object_value: {object_value} (object_types={object_type})"
+        )
+
     if object_value == "*":
         # Fact Chain value -> do not validate
         return True

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-types",
-    version="2.0.2",
+    version="2.0.3",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -1,12 +1,12 @@
-from act.types.format import format_threat_actor, format_tool
+from act.types.format import object_format
 
 
 def test_tool_format():
-    assert format_tool("Mimikatz") == "mimikatz"
-    assert format_tool("Super (awesome) tool") == "super tool"
+    assert object_format("tool", "Mimikatz") == "mimikatz"
+    assert object_format("tool", "Super (awesome) tool") == "super tool"
 
 
 def test_threatactor_format():
-    assert format_threat_actor("APT28") == "apt28"
-    assert format_threat_actor("APT28 ") == "apt28"
-    assert format_threat_actor("supER+@ta") == "super+@ta"
+    assert object_format("threatActor", "APT28") == "apt28"
+    assert object_format("threatActor", "APT28 ") == "apt28"
+    assert object_format("threatActor", "supER+@ta") == "super+@ta"

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,3 +1,5 @@
+import pytest
+
 from act.types.types import object_validates
 
 PLACEHOLDER = (
@@ -5,10 +7,18 @@ PLACEHOLDER = (
 )
 
 
+def test_validator_non_string():
+    with pytest.raises(TypeError):
+        object_validates("tool", 1)
+
+    with pytest.raises(TypeError):
+        object_validates("tool", None)
+
+
 def test_tool_validator():
     assert object_validates("tool", "Mimikatz") is False
     assert object_validates("tool", "mimikatz") is True
-    assert object_validates("tool", "many 0days: ie") is False
+    assert object_validates("tool", "many 0days: ie") is True
 
 
 def test_threatactor_validator():


### PR DESCRIPTION
* Raise `TypeError` if `object_value` is not Text in `object_validate`
* Update tests (that was not updated after refactoring
* Fix object_validator test for tools, as the tool validator is now less strict