### PR TITLE
use `open` context manager to make sure file is closed

### DIFF
--- a/act/types/types.py
+++ b/act/types/types.py
@@ -6,7 +6,7 @@ import functools
 import json
 import os
 import re
-from typing import Dict, List, Text
+from typing import Any, Dict, List, Text
 
 from pkg_resources import resource_filename
 
@@ -73,7 +73,7 @@ def object_validates(object_type: Text, object_value: Text) -> bool:
     return False
 
 
-def load_types(filename: Text) -> List[Dict]:
+def load_types(filename: Text) -> List[Dict[Text, Any]]:
     """
     Parse as json, and exit on parse error
     """
@@ -81,7 +81,8 @@ def load_types(filename: Text) -> List[Dict]:
         raise TypeLoadError(f"File not found: {filename}")
 
     try:
-        types = json.loads(open(filename, encoding="UTF8").read())
+        with open(filename, encoding="UTF8") as f:
+            types = json.load(f)
     except json.decoder.JSONDecodeError:
         raise TypeLoadError(f"Unable to parse file as json: {filename}")
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="act-types",
-    version="2.0.5",
+    version="2.0.6",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",


### PR DESCRIPTION
We got an report that the followin warning can be observed:

```
/usr/local/lib/python3.9/dist-packages/act/types/types.py:84: ResourceWarning:
unclosed file <_io.TextIOWrapper
name='/usr/local/lib/python3.9/dist-packages/act/types/etc/object-types.json'
mode='r' encoding='UTF8'> types = json.loads(open(filename,
encoding="UTF8").read()) ResourceWarning: Enable tracemalloc to get the object
allocation traceback
```